### PR TITLE
Put streamlit in ECS behind Cognito auth

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -40,4 +40,20 @@ NagSuppressions.addStackSuppressions(stack, [
     id: "AwsSolutions-APIG1",
     reason: "Websockets don't have this option yet.",
   },
+  {
+    id:"AwsSolutions-IAM4",
+    reason: "Managed policies are fine imo.",
+  },
+  {
+    id:"AwsSolutions-ECS2",
+    reason: "I agree that SystemsManger might be better for this, but even if I made that change, I would still have to pass in the systems manager variable name as an environment variable, which would still trigger this error.",
+  },
+  {
+    id:"AwsSolutions-EC23",
+    reason: "This warning is for a security group containing my application load balancer, which needs to be generally accesible from the internet."
+  },
+  {
+    id:"AwsSolutions-ELB2",
+    reason: "Not needed at this point imo."
+  }
 ]);

--- a/cdk/lib/llmGateway.ts
+++ b/cdk/lib/llmGateway.ts
@@ -541,8 +541,6 @@ export class LlmGatewayStack extends cdk.Stack {
       image: ecs.ContainerImage.fromEcrRepository(ecrRepoStreamlit, "latest"),
       logging: ecs.LogDrivers.awsLogs({ logGroup, streamPrefix: 'streamlit' }),
       environment: { 
-        BASE_URL: 'https://api.example.com', // Should be dynamically set as per your requirements
-        API_KEY: 'your-api-key', // Should be securely managed
         WebSocketURL: api.apiEndpoint
       },
       healthCheck: {

--- a/cdk/lib/llmGateway.ts
+++ b/cdk/lib/llmGateway.ts
@@ -2,6 +2,7 @@ import * as apigw from "aws-cdk-lib/aws-apigateway";
 import * as cdk from "aws-cdk-lib";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as ecr from "aws-cdk-lib/aws-ecr";
 import * as fs from "fs";
@@ -16,6 +17,9 @@ import { WebSocketLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integra
 import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
 import * as apigatewayv2_auth from "aws-cdk-lib/aws-apigatewayv2-authorizers"
 import * as lambdaNode from "aws-cdk-lib/aws-lambda-nodejs"
+import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2"
+import * as elbv2Actions from "aws-cdk-lib/aws-elasticloadbalancingv2-actions";
+import * as route53 from "aws-cdk-lib/aws-route53";
 /* At present, this repository supports:
  *  "ai21.j2-mid-v1": {},
  *  "ai21.j2-ultra-v1": {},
@@ -45,6 +49,9 @@ export class LlmGatewayStack extends cdk.Stack {
   vpcSecurityGroup = process.env.VPC_SECURITY_GROUP || null;
   architecture = this.node.tryGetContext('architecture');
   apiGatewayType = this.node.tryGetContext("apiGatewayType");
+  streamlitEcrRepoName = String(this.node.tryGetContext("ecrStreamlitRepository"));
+  uiCertArn = String(this.node.tryGetContext("uiCertArn"));
+  uiDomainName = String(this.node.tryGetContext("uiDomainName"));
 
   tryGetParameter(parameterName: string, defaultValue: any = null) {
     const parameter = this.node.tryFindChild(parameterName) as cdk.CfnParameter;
@@ -447,60 +454,215 @@ export class LlmGatewayStack extends cdk.Stack {
       advancedSecurityMode:cognito.AdvancedSecurityMode.ENFORCED,
     });
 
-    const userPoolClient = new cognito.UserPoolClient(this, "userPoolClient", {
-      userPool: userPool,
-      authFlows: { 
-        userPassword: true,
-        adminUserPassword: true 
+    const azureAdDomainPrefix = "llmgatewaymichaeltest123"
+
+    const cognitoDomain = userPool.addDomain('CognitoDomain', {
+      cognitoDomain: {
+        domainPrefix: azureAdDomainPrefix,
       },
     });
 
-
-    const authHandler = new lambdaNode.NodejsFunction(this, "AuthHandlerFunction", {
-      runtime: lambda.Runtime.NODEJS_20_X,
-      entry: path.join(__dirname, "authorizers/websocket/index.ts"),
-      architecture: this.architecture == "x86" ? lambda.Architecture.X86_64 : lambda.Architecture.ARM_64,
-      environment: {
-        USER_POOL_ID: userPool.userPoolId,
-        APP_CLIENT_ID: userPoolClient.userPoolClientId,
-      },
-      bundling: {
-        minify: false,
-      },
-      role: new iam.Role(this, "AuthHandlerRole", {
-        assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
-        roleName: "AuthHandlerRole",
-        inlinePolicies: {
-          LambdaPermissions: new iam.PolicyDocument({
-            statements: [
-              new iam.PolicyStatement({
-                sid: "WriteToCloudWatchLogs",
-                effect: iam.Effect.ALLOW,
-                actions: [
-                  "logs:CreateLogGroup",
-                  "logs:CreateLogStream",
-                  "logs:PutLogEvents",
-                ],
-                resources: ["*"],
-              }),
-            ],
-          }),
+    const applicationLoadBalanceruserPoolClient = new cognito.UserPoolClient(this, 'client', {
+      userPoolClientName: 'ApplicationLoadBalancerClient',
+      userPool,
+      generateSecret: true,
+      oAuth: {
+        callbackUrls: [`https://${this.uiDomainName}/oauth2/idpresponse`, `https://${this.uiDomainName}/*`],
+        flows: {
+          authorizationCodeGrant: true
         },
+        scopes: [
+          cognito.OAuthScope.OPENID,
+          cognito.OAuthScope.EMAIL
+        ],
+      },
+      supportedIdentityProviders: [cognito.UserPoolClientIdentityProvider.COGNITO],
+    });
+
+    const vpc = new ec2.Vpc(this, 'MyVPC', { });
+    const flowLog = new ec2.FlowLog(this, 'FlowLog', {
+      resourceType: ec2.FlowLogResourceType.fromVpc(vpc),
+      trafficType: ec2.FlowLogTrafficType.ALL,
+    });
+
+    // Create ECS Cluster
+    const cluster = new ecs.Cluster(this, 'AppCluster', {
+      vpc,
+      clusterName: 'LlmGatewayUI',
+      containerInsights:true,
+      
+    });
+
+    const logGroup = new logs.LogGroup(this, 'AppLogGroup', {
+      logGroupName: '/ecs/LlmGateway/StreamlitUI',
+      removalPolicy: cdk.RemovalPolicy.DESTROY
+    });
+
+    const ecsExecutionRole = new iam.Role(this, 'EcsExecutionRole', {
+      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
+      roleName: 'LlmGatewayUIRole'
+    });
+
+    ecsExecutionRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonECSTaskExecutionRolePolicy'));
+
+    const stageName = 'prod'; 
+
+    const connectArn = `arn:aws:execute-api:${this.regionValue}:${this.account}:${api.apiId}/${stageName}/$connect`
+
+    const disconnectArn = `arn:aws:execute-api:${this.regionValue}:${this.account}:${api.apiId}/${stageName}/$disconnect`
+
+    const sendMessageArn = `arn:aws:execute-api:${this.regionValue}:${this.account}:${api.apiId}/${stageName}/sendmessage`
+
+    const policyStatement = new iam.PolicyStatement({
+      actions: ['execute-api:Invoke'],
+      resources: [connectArn, disconnectArn, sendMessageArn],
+      effect: iam.Effect.ALLOW
+    });
+
+    ecsExecutionRole.addToPolicy(policyStatement);
+
+    const taskDefinition = new ecs.FargateTaskDefinition(this, 'TaskDef', {
+      memoryLimitMiB: 512,
+      cpu: 256,
+      executionRole: ecsExecutionRole,
+      taskRole: ecsExecutionRole,
+      runtimePlatform: {
+        cpuArchitecture: this.architecture == "x86" ? ecs.CpuArchitecture.X86_64 : ecs.CpuArchitecture.ARM64,
+      }
+    });
+
+    const ecrRepoStreamlit = ecr.Repository.fromRepositoryName(
+      this,
+      this.streamlitEcrRepoName!,
+      this.streamlitEcrRepoName!
+    );
+
+    const container = taskDefinition.addContainer('streamlit', {
+      image: ecs.ContainerImage.fromEcrRepository(ecrRepoStreamlit, "latest"),
+      logging: ecs.LogDrivers.awsLogs({ logGroup, streamPrefix: 'streamlit' }),
+      environment: { 
+        BASE_URL: 'https://api.example.com', // Should be dynamically set as per your requirements
+        API_KEY: 'your-api-key', // Should be securely managed
+        WebSocketURL: api.apiEndpoint
+      },
+      healthCheck: {
+        command: ['CMD-SHELL', 'curl -f http://localhost:8501/healthz || exit 1'],
+        interval: cdk.Duration.seconds(30),
+        timeout: cdk.Duration.seconds(5),
+        retries: 3,
+        startPeriod: cdk.Duration.seconds(60)
+      }
+    });
+
+    container.addPortMappings({
+      containerPort: 8501,
+      hostPort: 8501
+    });
+
+    const albSecurityGroup = new ec2.SecurityGroup(this, 'ALBSecurityGroup', {
+      securityGroupName: 'LlmGatewayALB-sg',
+      vpc,
+      allowAllOutbound: true,
+    });
+
+    albSecurityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(80));
+    albSecurityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(443));
+
+    const appSecurityGroup = new ec2.SecurityGroup(this, 'AppSecurityGroup', {
+      securityGroupName: 'LlmGatewayUI-sg',
+      vpc,
+      allowAllOutbound: true,
+    });
+
+    appSecurityGroup.addIngressRule(albSecurityGroup, ec2.Port.tcp(8501));
+
+    const service = new ecs.FargateService(this, 'Service', {
+      serviceName: "LlmGatewayUI",
+      cluster,
+      taskDefinition,
+      desiredCount: 1,
+      securityGroups: [appSecurityGroup],
+      assignPublicIp: false,
+      circuitBreaker: {
+        enable:true,
+        rollback:true
+      }
+    });
+
+    const lb = new elbv2.ApplicationLoadBalancer(this, 'LB', {
+      vpc,
+      internetFacing: true,
+      securityGroup: albSecurityGroup,
+    });
+
+    const targetGroup = new elbv2.ApplicationTargetGroup(this, 'AppTG', {
+      vpc,
+      targetGroupName: 'LlmGatewayUI',
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      targetType: elbv2.TargetType.IP,
+      port: 8501,
+      targets: [service]
+    });
+
+    const appListener = lb.addListener('appListener', {
+      port: 443,
+      protocol: elbv2.ApplicationProtocol.HTTPS,
+      certificates: [{ certificateArn: this.uiCertArn }],
+      defaultAction: elbv2.ListenerAction.fixedResponse(200, {
+        contentType: "text/plain",
+        messageBody: "This is the default action."
+      }),
+    });
+
+    const appListener80 = lb.addListener('appListener80', {
+      port: 80,
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      defaultAction: elbv2.ListenerAction.redirect({
+        port:"443",
+        protocol: "HTTPS",
+        permanent: true
       })
     });
 
-    const authorizer = new apigatewayv2_auth.WebSocketLambdaAuthorizer(
-      "Authorizer",
-      authHandler,
-      {
-        identitySource: ["route.request.header.Authorization"],
-      },
-    );
+
+    appListener.addAction("authenticate-cognito", {
+      priority: 10,
+      conditions: [elbv2.ListenerCondition.pathPatterns(["/", "/*"])],
+      action: new elbv2Actions.AuthenticateCognitoAction({
+        userPool:userPool,
+        userPoolClient: applicationLoadBalanceruserPoolClient,
+        userPoolDomain: cognitoDomain,
+        next: elbv2.ListenerAction.forward([targetGroup])
+      })
+    });
+
+    const domainParts = this.uiDomainName.split(".");
+    const domainName = domainParts.slice(1).join(".");
+    const hostName = domainParts[0];
+
+    // Retrieve the existing Route 53 hosted zone
+    const hostedZone = route53.HostedZone.fromLookup(this, 'Zone', {
+      domainName: `${domainName}.`
+    });
+
+    // Create Route 53 A record pointing to the ALB
+    new route53.ARecord(this, 'AliasRecord', {
+      zone: hostedZone,
+      recordName: hostName,
+      target: route53.RecordTarget.fromAlias({
+        bind: () => ({
+          dnsName: lb.loadBalancerDnsName,
+          hostedZoneId: lb.loadBalancerCanonicalHostedZoneId,
+          evaluateTargetHealth: true,
+        })
+      })
+    });
+
 
     // Create endpoints
     api.addRoute("$connect", {
       integration: new WebSocketLambdaIntegration("ConnectIntegration", fn),
-      authorizer
+      authorizer: new apigatewayv2_auth.WebSocketIamAuthorizer
     });
     api.addRoute("$disconnect", {
       integration: new WebSocketLambdaIntegration("DisconnectIntegration", fn),
@@ -517,7 +679,7 @@ export class LlmGatewayStack extends cdk.Stack {
 
     // Output the User Pool Client ID
     new cdk.CfnOutput(this, 'UserPoolClientId', {
-      value: userPoolClient.userPoolClientId,
+      value: applicationLoadBalanceruserPoolClient.userPoolClientId,
       description: 'The ID of the User Pool Client',
     });
 
@@ -529,6 +691,11 @@ export class LlmGatewayStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'WebSocketLambdaFunctionName', {
       value: fn.functionName,
       description: 'Name of the websocket lambda function'
+    });
+
+    new cdk.CfnOutput(this, 'StreamlitUiUrl', {
+      value: "https://" + this.uiDomainName,
+      description: 'The url of the streamlit UI'
     });
 
     return api;

--- a/streamlit/Dockerfile
+++ b/streamlit/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/docker/library/alpine:edge@sha256:e31c3b1cd47718260e1b6163af0a05b3c428dc01fa410baf72ca8b8076e22e72
+RUN apk update && apk add python3 py3-pip py3-pyarrow curl
+RUN addgroup -S streamlit && adduser -S -G streamlit streamlit
+RUN mkdir /app && chown streamlit:streamlit /app
+COPY requirements.txt /app/
+WORKDIR /app
+RUN pip3 install --break-system-packages -r requirements.txt
+COPY app.py /app/
+COPY invoke_llm_with_streaming.py /app/
+USER streamlit
+HEALTHCHECK --interval=30s --timeout=5s CMD curl -f http://localhost:8501/healthz || exit 1
+CMD ["/usr/bin/streamlit", "run", "app.py"]
+

--- a/streamlit/app.py
+++ b/streamlit/app.py
@@ -1,0 +1,289 @@
+import streamlit as st
+from invoke_llm_with_streaming import llm_answer_streaming
+import asyncio
+import threading
+import queue
+import websockets
+
+st.set_page_config(layout="wide")
+
+quota_limit = 0.0001
+
+# Initialize the variable
+is_streaming = False
+
+
+################################################################################
+# BEGIN - Lambda code - This needs to be migrated to the cloud
+################################################################################
+
+import re
+import csv
+
+# ANY_WORD = "([a-zA-Z]+)"
+# UP_TO_3_DIGITS = "([\d]{1,3})"
+# PUNCTUATION = ".?!,\/\(\);:~=@%'\n"
+# UP_TO_3_PUNCTUATION = f"([{PUNCTUATION}]{1,3}+(?=(.?.?.?)*))"
+# ANY_NON_ASCII_CHAR = "(\\\\x[0-9a-fA-F]{2})"
+
+# PATTERN = f"{ANY_WORD}|{UP_TO_3_DIGITS}|{ANY_NON_ASCII_CHAR}|{UP_TO_3_PUNCTUATION}"
+
+# COST_DB = "../data/cost_db.csv"
+if 'model_id' not in st.session_state:
+    st.session_state['model_id'] = None
+
+def initialize_dependent_values():
+    # Initialize or reset values that are dependent on main_column
+    st.session_state['model_id'] = "anthropic.claude-3-sonnet-20240229-v1:0"  # Placeholder or default
+
+# def get_estimated_tokens(s: str) -> int:
+#     """
+#     Counts the number of tokens in the given string `s`, according to the
+#     following method:
+
+#     - All words (characters in [a-zA-Z] separated by whitespace or _, count as 1 token.
+#     - Numbers and punctuation are put into groups of 1-3 digits. Each group counts as 1 token.
+#     - All non ascii characters count as 1 token per byte.
+#     """
+
+#     s_encoded = s.encode("utf-8")
+
+#     result = re.findall(PATTERN, str(s_encoded)[2:])
+#     return [item for tup in result for item in tup if item]
+
+
+def has_quota():
+    return True
+    # return not (
+    #     st.session_state.estimated_usage and
+    #     st.session_state.estimated_usage > quota_limit
+    # )
+
+
+# def estimate_cost(
+#     model: str,
+#     region: str,
+#     type_: str,
+#     string: str,
+#     use_cache:bool=False,
+# ) -> float:
+#     if type_ not in ["input", "output"]:
+#         raise Exception("`type_` must be one of [\"input\", \"output\"]")
+
+#     key = ",".join([model, region, type_])
+
+#     if use_cache:  # Skip the DDB step for better cost / time performance
+#         with open(COST_DB) as f:
+#             reader = csv.DictReader(f)
+#             costs_dict = {}
+#             for row in reader:
+#                 model_name = row["model_name"]
+#                 type_ = row["type"]
+#                 region = row["region"]
+#                 cost = float(row["cost_per_token"])
+
+#                 costs_dict[",".join([model_name,region,type_])] = cost
+
+#             cost_per_k_tokens = costs_dict.get(key)
+
+#             if not cost_per_k_tokens:
+#                 print(costs_dict)
+#                 raise Exception(
+#                     f"Could not find ({model}, {region}, {type_}) in cost DB."
+#                 )
+
+#             cost_per_token = cost_per_k_tokens / 1000
+#     else:  # Lookup in DDB
+#         raise NotImplemented()
+
+#     n_tokens = len(get_estimated_tokens(string))
+
+#     return cost_per_token * n_tokens
+
+################################################################################
+# END - Lambda code
+################################################################################
+
+metrics = {
+    "n_input_tokens": 0,
+    "n_output_tokens": 0,
+    "input_cost": 0,
+    "output_cost": 0,
+}
+
+
+def bridge(async_gen, sync_queue):
+    async def run():
+        async for item in async_gen:
+            sync_queue.put(item)
+        sync_queue.put(None)  # Signal that the generator is done
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(run())
+    loop.close()
+
+
+def sync_generator(sync_queue):
+    while True:
+        item = sync_queue.get()
+        if item is None:
+            break
+        yield item
+
+
+# def update_metrics(s, type_):
+#     print(metrics)
+#     metrics[f"n_{type_}_tokens"] = len(get_estimated_tokens(s))
+#     metrics[f"{type_}_cost"] = estimate_cost(
+#         "anthropic.claude-instant",
+#         "us-east-1",
+#         type_,
+#         s,
+#         use_cache=True
+#     )
+#     print(metrics)
+
+
+# Create two columns
+main_column, right_column = st.columns([3, 1])
+
+with main_column:
+    if st.session_state.model_id == None:
+        initialize_dependent_values()
+
+    # Title displayed on the streamlit web app
+    st.title(f""":rainbow[LLM Gateway API Sample]""")
+    # configuring values for session state
+    if "messages" not in st.session_state:
+        st.session_state.messages = []
+    if "estimated_usage" not in st.session_state:
+        st.session_state.estimated_usage = 0
+    # writing the message that is stored in session state
+    for message in st.session_state.messages:
+        with st.chat_message(message["role"]):
+            st.markdown(message["content"])
+
+    # evaluating st.chat_input and determining if a prompt has been input
+    if prompt := st.chat_input("Ask me about anything..."):
+        # with the user icon, write the prompt to the front end
+        with st.chat_message("user"):
+            st.markdown(prompt)
+        # append the prompt and the role (user) as a message to the session state
+        st.session_state.messages.append({"role": "user", "content": prompt})
+        # respond as the assistant with the answer
+        with st.chat_message("assistant"):
+            q = queue.Queue()
+
+            if has_quota():
+                # Update the input metrics.
+                #update_metrics(prompt, "input")
+
+                # Start the background thread
+
+                print(f'st.session_state.model_id: {st.session_state.model_id}')
+                thread = threading.Thread(
+                    target=bridge, args=(llm_answer_streaming(prompt, st.session_state.model_id), q)
+                )
+                thread.start()
+                # making sure there are no messages present when generating the answer
+                message_placeholder = st.empty()
+                # calling the invoke_llm_with_streaming to generate the answer as a generator object, and using
+                # st.write stream to perform the actual streaming of the answer to the front end
+                answer = st.write_stream(sync_generator(q))
+            else:
+                answer = st.write("Quota limit exceeded.")
+
+        # appending the final answer to the session state
+        if has_quota():
+            #update_metrics(answer, "output")
+            print(st.session_state.estimated_usage)
+            st.session_state.estimated_usage += metrics["input_cost"]
+            st.session_state.estimated_usage += metrics["output_cost"]
+        st.session_state.messages.append({"role": "assistant", "content": answer})
+
+with right_column:
+    # Control items
+    is_streaming = st.toggle("Stream responses?")
+
+    st.header("Usage Statistics")
+    # Your usage statistics functionality goes here
+
+    user_options = ["Oz's User", "Andrew's AWS App", "Michael's Azure App"]
+    selected_user = st.selectbox("User", user_options)
+
+    provider_options = ["Amazon Bedrock", "Azure & OpenAI"]
+    provider = st.selectbox("Provider", provider_options)
+
+    model_map = {
+            "Claude 3 Sonnet": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "Claude 3 Haiku": "anthropic.claude-3-haiku-20240307-v1:0",
+            "Llama 3": "meta.llama3-70b-instruct-v1:0",
+            "Amazon Titan G1 Express": "amazon.titan-text-express-v1",
+            "Mixtral 8x7B Instruct": "mistral.mixtral-8x7b-instruct-v0:1",
+            "OpenAI GPT 3.5": "gpt-3.5-turbo",
+            "OpenAI GPT 4": "gpt-4-turbo"
+        }
+
+    if provider == "Amazon Bedrock":
+        # Model dropdown
+        model_options = [
+            "Claude 3 Sonnet",
+            "Claude 3 Haiku",
+            "Llama 3",
+            "Amazon Titan G1 Express",
+            "Mixtral 8x7B Instruct",
+        ]
+    elif provider == "Azure & OpenAI":
+        # Model dropdown
+        model_options = ["OpenAI GPT 3.5", "OpenAI GPT 4"]
+
+    selected_model = st.session_state.model_selection = st.selectbox(
+            "Select Model",
+            options=model_options,
+        )
+
+    st.session_state.model_id = model_map[selected_model]
+
+    # Quota limit
+    if has_quota():
+        st.subheader(f"Response received")
+    else:  # No quota left.
+        error_message = "Quota limit exceeded"
+        st.subheader(f"LLM Gateway Exception - {error_message}")
+
+    if st.session_state.estimated_usage:
+        estimated_usage_str = '{:8f}'.format(st.session_state.estimated_usage)
+    else:
+        estimated_usage_str = "0"
+    st.write(f"""
+    - Model Selected: {st.session_state.model_selection}
+    - Model Id: {st.session_state.model_id}
+    - User: {selected_user}
+    - Quota Plan: Daily
+    - Estimated usage for this period: \$ {estimated_usage_str} / \$ {quota_limit}
+    """)
+
+    n_input_tokens = metrics["n_input_tokens"]
+    n_output_tokens = metrics["n_output_tokens"]
+    input_cost = metrics["input_cost"]
+    output_cost = metrics["output_cost"]
+
+    st.write(f"""
+    ##### Input metrics:
+    - n_tokens: {n_input_tokens}
+    - cost: $ {input_cost}
+    """)
+
+    st.write(f"""
+    ##### Output metrics:
+    - n_tokens: {n_output_tokens}
+    - cost: $ {output_cost}
+    """)
+
+    st.write(f"""
+    ##### Combined I/O metrics:
+    - n_tokens: {n_output_tokens + n_input_tokens}
+    - cost: $ {float(output_cost) + float(input_cost)}
+    """)
+

--- a/streamlit/build_and_deploy.sh
+++ b/streamlit/build_and_deploy.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <APP_NAME>"
+  exit 1
+fi
+
+APP_NAME=$1
+
+AWS_REGION=$(aws configure get region)
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+
+# Check if the repository already exists
+REPO_EXISTS=$(aws ecr describe-repositories --repository-names $APP_NAME 2>/dev/null)
+
+if [ -z "$REPO_EXISTS" ]; then
+    # Repository does not exist, create it
+    aws ecr create-repository --repository-name $APP_NAME
+else
+    echo "Repository $APP_NAME already exists, skipping creation."
+fi
+
+ARCH=$(uname -m)
+case $ARCH in
+    x86_64)
+        ARCH="linux/amd64"
+        ;;
+    arm64)
+        ARCH="linux/arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+echo $ARCH
+
+aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+docker build --platform $ARCH -t $APP_NAME .
+docker tag $APP_NAME\:latest $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$APP_NAME\:latest
+docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$APP_NAME\:latest

--- a/streamlit/invoke_llm_with_streaming.py
+++ b/streamlit/invoke_llm_with_streaming.py
@@ -1,0 +1,158 @@
+import boto3
+import json
+import botocore.config
+import os
+from dotenv import load_dotenv
+import streamlit as st
+import websockets
+import threading
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.session import Session
+from urllib.parse import urlparse, urlunparse
+
+# loading in environment variables
+load_dotenv()
+
+# configuring our CLI profile name
+boto3.setup_default_session(profile_name=os.getenv('profile_name'))
+# increasing the timeout period when invoking bedrock
+config = botocore.config.Config(connect_timeout=120, read_timeout=120)
+# instantiating the bedrock client
+region = boto3.Session().region_name
+bedrock = boto3.client('bedrock-runtime', region, endpoint_url=f'https://bedrock-runtime.{region}.amazonaws.com',
+                       config=config)
+
+WebSocketURL = os.environ["WebSocketURL"]
+
+# resources_file_path = '../cdk/resources.txt'
+# scripts_resources_file_path = '../scripts/resources.txt'
+# Initialize variables to hold the values
+# UserPoolID = None
+# UserPoolClientID = None
+# WebSocketURL = None
+# Username = None
+# Password = None
+
+# if os.path.exists(resources_file_path):
+#     # Open the file and read the contents
+#     with open(resources_file_path, 'r') as file:
+#         # Iterate over each line in the file
+#         for line in file:
+#             stripped_line = line.strip()
+#             if '=' in stripped_line:
+#                 # Split the line into key and value on the '=' character
+#                 key, value = line.strip().split('=')
+#                 # Assign the value to the appropriate variable based on the key
+#                 if key == 'UserPoolID':
+#                     UserPoolID = value
+#                 elif key == 'UserPoolClientID':
+#                     UserPoolClientID = value
+#                 elif key == 'WebSocketURL':
+#                     WebSocketURL = value
+# else:
+#     print(f"Error: The file {resources_file_path} does not exist")
+
+# if os.path.exists(scripts_resources_file_path):
+#     # Open the file and read the contents
+#     with open(scripts_resources_file_path, 'r') as file:
+#         # Iterate over each line in the file
+#         for line in file:
+#             stripped_line = line.strip()
+#             if '=' in stripped_line:
+#                 # Split the line into key and value on the '=' character
+#                 key, value = line.strip().split('=')
+#                 # Assign the value to the appropriate variable based on the key
+#                 if key == 'Username':
+#                     Username = value
+#                 elif key == 'Password':
+#                     Password = value
+# else:
+#     print(f"Error: The file {scripts_resources_file_path} does not exist")
+
+# print(f'UserPoolID: {UserPoolID}')
+# print(f'UserPoolClientID: {UserPoolClientID}')
+print(f'WebSocketURL: {WebSocketURL}')
+# print(f'Username: {Username}')
+# print(f'Password: {Password}')
+
+class ThreadSafeSessionState:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.session_state = {}
+
+    def get(self, key):
+        with self.lock:
+            return self.session_state.get(key)
+
+    def set(self, key, value):
+        with self.lock:
+            self.session_state[key] = value
+
+thread_safe_session_state = ThreadSafeSessionState()
+
+# def authenticate_user(client_id, user_pool_id, username, password):
+#     client = boto3.client('cognito-idp', region_name=region)
+    
+#     response = client.initiate_auth(
+#         ClientId=client_id,
+#         AuthFlow='USER_PASSWORD_AUTH',
+#         AuthParameters={
+#             'USERNAME': username,
+#             'PASSWORD': password
+#         }
+#     )
+#     return response
+
+# Use this function to get the ID token
+# def get_id_token(client_id, user_pool_id, username, password):
+#     auth_response = authenticate_user(client_id, user_pool_id, username, password)
+#     #print("auth_response:", auth_response)
+#     id_token = auth_response['AuthenticationResult']['IdToken']
+#     return id_token
+
+async def llm_answer_streaming(question, model):
+    message = {"action": "sendmessage", "prompt": question, "model": model}
+    if thread_safe_session_state.get("chat_id"):
+        print(f'found chat id in context')
+        message["chat_id"] = thread_safe_session_state.get("chat_id")
+    else:
+        print(f'did not find chat id in context')
+    
+    # id_token = get_id_token(UserPoolClientID, UserPoolID, Username, Password)
+    # headers = {
+    #     "Authorization": f"Bearer {id_token}"
+    # }
+
+    #print(f'id_token: {id_token}')
+    full_url = f'{WebSocketURL}/prod'
+    #socket = await websockets.connect(full_url)#, extra_headers=headers)
+
+    session = boto3.Session()
+    credentials = session.get_credentials()
+    parsed_url = urlparse(full_url)
+    service = 'execute-api'
+
+    # Create a canonical request for signing
+    request = AWSRequest(method='GET', url=full_url, headers={'host': parsed_url.netloc})
+    SigV4Auth(credentials, service, region).add_auth(request)
+    signed_url = urlunparse([
+        parsed_url.scheme, parsed_url.netloc, parsed_url.path,
+        parsed_url.params, parsed_url.query, parsed_url.fragment
+    ])
+
+    
+    async with websockets.connect(signed_url, extra_headers=request.headers.items()) as websocket:
+        print(f"message: {message}")
+        await websocket.send(json.dumps(message))
+        while True:
+            response = await websocket.recv()
+            response_json = json.loads(response)
+            print(f'response_json: {response_json}')
+            completion = response_json.get("completion")
+            print(f'Assigning chat id: {response_json.get("chat_id")}')
+            thread_safe_session_state.set("chat_id", response_json.get("chat_id"))
+            if completion:
+                yield completion
+            if response_json.get("has_more_messages") == "false":
+                break

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -1,0 +1,4 @@
+boto3==1.28.58
+websockets==10.4
+streamlit==1.34.0
+python-dotenv==1.0.1

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.28.58
 websockets==10.4
 streamlit==1.34.0
 python-dotenv==1.0.1
+pyjwt==2.8.0


### PR DESCRIPTION
- Host Streamlit in ECS with a Route53 domain with a ACM Certificate behind an Application Load Balancer with Cognito Authentication (You must already have your Certificate with its Custom Domain before deployment)
- Have the Authenticated user's username correctly displayed in the Streamlit UI (We will use this username in the future to do user-based rate-limiting, and possibly user-based LLM Model access control) 